### PR TITLE
Change "check_rbl_sub()" to "check_rbl()" to make RCVD_IN_SBL, RCVD_IN_SBL_CSS, and RCVD_IN_SBL_DROP work

### DIFF
--- a/sh.cf
+++ b/sh.cf
@@ -21,11 +21,11 @@ ifplugin Mail::SpamAssassin::Plugin::SH
     shortcircuit	RCVD_IN_ZEN_LASTEXTERNAL	spam
   endif # Mail::SpamAssassin::Plugin::Shortcircuit
 
-  header	__RCVD_IN_SBL		eval:check_rbl_sub('zendqs', 'your_DQS_key.zen.dq.spamhaus.net.', '^127\.0\.0\.2$')
+  header	__RCVD_IN_SBL		eval:check_rbl('zendqs', 'your_DQS_key.zen.dq.spamhaus.net.', '^127\.0\.0\.2$')
   meta		RCVD_IN_SBL		__RCVD_IN_SBL
-  header	__RCVD_IN_SBL_CSS	eval:check_rbl_sub('zendqs', 'your_DQS_key.zen.dq.spamhaus.net.', '^127\.0\.0\.3$')
+  header	__RCVD_IN_SBL_CSS	eval:check_rbl('zendqs', 'your_DQS_key.zen.dq.spamhaus.net.', '^127\.0\.0\.3$')
   meta		RCVD_IN_SBL_CSS		__RCVD_IN_SBL_CSS
-  header	__RCVD_IN_SBL_DROP	eval:check_rbl_sub('zendqs', 'your_DQS_key.zen.dq.spamhaus.net.', '^127\.0\.0\.9$')
+  header	__RCVD_IN_SBL_DROP	eval:check_rbl('zendqs', 'your_DQS_key.zen.dq.spamhaus.net.', '^127\.0\.0\.9$')
   meta		RCVD_IN_SBL_DROP	__RCVD_IN_SBL_DROP
 
 #  score		RCVD_IN_XBL		0


### PR DESCRIPTION
Change "check_rbl_sub()" to "check_rbl()" to make RCVD_IN_SBL, RCVD_IN_SBL_CSS, and RCVD_IN_SBL_DROP work:

While examining logs, I noticed that none of these rules have triggered since I switched to DQS: RCVD_IN_SBL, RCVD_IN_SBL_CSS, RCVD_IN_SBL_DROP.

This is because the code uses check_rbl_sub() with three parameters (including a zone parameter) for these rules, instead of the correct check_rbl() with three parameters or check_rbl_sub() with two parameters (check_rbl_sub should not include a zone).

This commit fixes that, using check_rbl() with three parameters for consistency with other rules in the file.