### PR TITLE
Avoid duplicated lookups by using zen instead of sbl-xbl

### DIFF
--- a/sh.cf
+++ b/sh.cf
@@ -70,19 +70,19 @@ ifplugin Mail::SpamAssassin::Plugin::SH
     endif # if can
   endif   # Mail::SpamAssassin::Plugin::URIDNSBL
 
-  body		SH_BODYURI_REVERSE_SBL	eval:check_sh_bodyuri_a('your_DQS_key.sbl-xbl.dq.spamhaus.net', '^127\.0\.0\.2')
+  body		SH_BODYURI_REVERSE_SBL	eval:check_sh_bodyuri_a('your_DQS_key.zen.dq.spamhaus.net', '^127\.0\.0\.2')
   priority	SH_BODYURI_REVERSE_SBL	-100
   describe	SH_BODYURI_REVERSE_SBL The corrisponding A record of an URI contained in the body is listed in SBL
 
-  body		SH_BODYURI_REVERSE_CSS	eval:check_sh_bodyuri_a('your_DQS_key.sbl-xbl.dq.spamhaus.net', '^127\.0\.0\.3')
+  body		SH_BODYURI_REVERSE_CSS	eval:check_sh_bodyuri_a('your_DQS_key.zen.dq.spamhaus.net', '^127\.0\.0\.3')
   priority	SH_BODYURI_REVERSE_CSS	-100
   describe	SH_BODYURI_REVERSE_CSS  The corrisponding A record of an URI contained in the body is listed in CSS
 
-  body		SH_BODYURI_REVERSE_DROP	eval:check_sh_bodyuri_a('your_DQS_key.sbl-xbl.dq.spamhaus.net', '^127\.0\.0\.9')
+  body		SH_BODYURI_REVERSE_DROP	eval:check_sh_bodyuri_a('your_DQS_key.zen.dq.spamhaus.net', '^127\.0\.0\.9')
   priority	SH_BODYURI_REVERSE_DROP	-100
   describe	SH_BODYURI_REVERSE_DROP  The corrisponding A record of an URI contained in the body is listed in DROP
 
-  body		SH_BODYURI_REVERSE_XBL	eval:check_sh_bodyuri_a('your_DQS_key.sbl-xbl.dq.spamhaus.net', '^127\.0\.0\.4')
+  body		SH_BODYURI_REVERSE_XBL	eval:check_sh_bodyuri_a('your_DQS_key.zen.dq.spamhaus.net', '^127\.0\.0\.4')
   priority	SH_BODYURI_REVERSE_XBL	-100
   describe	SH_BODYURI_REVERSE_XBL  The corrisponding A record of an URI contained in the body is listed in XBL
 


### PR DESCRIPTION
I noticed that the plugin often makes otherwise-identical queries to both "zen.dq.spamhaus.net" and "sbl-xbl.dq.spamhaus.net". Some of the rules explicitly mention sbl-xbl, but that seems unnecessary. Replacing those with zen avoids duplicate lookups.

Before this change, a SpamAssassin debug log would often show something like:

async: launching A/1.113.0.203.key.zen.dq.spamhaus.net for DNSBL:1.113.0.203:key.zen.dq.spamhaus.net
async: launching A/1.113.0.203.key.sbl-xbl.dq.spamhaus.net for SH:1.113.0.203.key.sbl-xbl.dq.spamhaus.net

With this change, it only does the first of these. The results otherwise seem identical.