### PR TITLE
Make sure that "example.com" is never wrongly recognized as "example.co" due to the random order of TLDs in $self->{main}->{registryboundaries}->{valid_tlds_re}

### DIFF
--- a/SH.pm
+++ b/SH.pm
@@ -121,18 +121,35 @@ sub _init_email_re {
   }
   # Some regexp tips courtesy of http://www.regular-expressions.info/email.html
   # full email regex v0.02
-  $self->{email_regex} = qr/
-    (?=.{0,64}\@)                       # limit userpart to 64 chars (and speed up searching?)
-    (?<![a-z0-9!#\$%&'*+\/=?^_`{|}~-])  # start boundary
-    (                                   # capture email
-    [a-z0-9!#\$%&'*+\/=?^_`{|}~-]+      # no dot in beginning
-    (?:\.[a-z0-9!#\$%&'*+\/=?^_`{|}~-]+)* # no consecutive dots, no ending dot
-    \@
-    (?:[a-z0-9](?:[a-z0-9-]{0,59}[a-z0-9])?\.){1,4} # max 4x61 char parts (should be enough?)
-    $self->{main}->{registryboundaries}->{valid_tlds_re} # ends with valid tld
-    )
-    (?!(?:[a-z0-9-]|\.[a-z0-9]))      # make sure domain ends here
-  /xi;
+  if ($sa_version < 343) {
+    # Add the "make sure domain ends here" code to prevent "example.com"
+    # from being wrongly parsed as "example.co" (this code is already present
+    # in SpamAssassin 3.4.3)
+    $self->{email_regex} = qr/
+      (?=.{0,64}\@)                       # limit userpart to 64 chars (and speed up searching?)
+      (?<![a-z0-9!#\$%&'*+\/=?^_`{|}~-])  # start boundary
+      (                                   # capture email
+      [a-z0-9!#\$%&'*+\/=?^_`{|}~-]+      # no dot in beginning
+      (?:\.[a-z0-9!#\$%&'*+\/=?^_`{|}~-]+)* # no consecutive dots, no ending dot
+      \@
+      (?:[a-z0-9](?:[a-z0-9-]{0,59}[a-z0-9])?\.){1,4} # max 4x61 char parts (should be enough?)
+      $self->{main}->{registryboundaries}->{valid_tlds_re} # ends with valid tld
+      )
+      (?!(?:[a-z0-9-]|\.[a-z0-9]))      # make sure domain ends here
+    /xi;
+  } else {
+    $self->{email_regex} = qr/
+      (?=.{0,64}\@)                       # limit userpart to 64 chars (and speed up searching?)
+      (?<![a-z0-9!#\$%&'*+\/=?^_`{|}~-])  # start boundary
+      (                                   # capture email
+      [a-z0-9!#\$%&'*+\/=?^_`{|}~-]+      # no dot in beginning
+      (?:\.[a-z0-9!#\$%&'*+\/=?^_`{|}~-]+)* # no consecutive dots, no ending dot
+      \@
+      (?:[a-z0-9](?:[a-z0-9-]{0,59}[a-z0-9])?\.){1,4} # max 4x61 char parts (should be enough?)
+      $self->{main}->{registryboundaries}->{valid_tlds_re} # ends with valid tld
+      )
+    /xi;
+  }
 # lazy man debug
 #open(my $fh, '>', "/tmp/reg") or die "Could not open file $!";
 #print $fh $self->{email_regex};

--- a/SH.pm
+++ b/SH.pm
@@ -131,6 +131,7 @@ sub _init_email_re {
     (?:[a-z0-9](?:[a-z0-9-]{0,59}[a-z0-9])?\.){1,4} # max 4x61 char parts (should be enough?)
     $self->{main}->{registryboundaries}->{valid_tlds_re} # ends with valid tld
     )
+    (?!(?:[a-z0-9-]|\.[a-z0-9]))      # make sure domain ends here
   /xi;
 # lazy man debug
 #open(my $fh, '>', "/tmp/reg") or die "Could not open file $!";


### PR DESCRIPTION
While testing  on a message that contained "address@example.com", I noticed that running it on the same message in debug mode would sometimes say:

dbg: SHPlugin: (_get_body_emails) found email address@example.com in body

And sometimes:

dbg: SHPlugin: (_get_body_emails) found email address@example.co in body

(note "example.co" instead of "example.com").

This happens because the regexp in $self->{main}->{registryboundaries}->{valid_tlds_re} has the TLDs in a random order on each run due to Perl hash randomization. Because ".co" and ".com" are both valid TLDs, the regexp sometimes looks like "(...|co|...|com|...)" and sometimes like "(...|com|...|co|...)", and the first one matches. This makes _get_body_emails not work half the time on ".com" addresses because it looks up the wrong domain name.

The fix is taken from package Mail::SpamAssassin::Plugin::FreeMail; it makes sure that there are not more "domain name like" characters after the end of the TLDs.