### PR TITLE
Consistently use $self->{'main'}->{'registryboundaries'}->uri_to_domain where appropriate

### DIFF
--- a/SH.pm
+++ b/SH.pm
@@ -628,7 +628,7 @@ sub check_sh_bodyuri_ns {
   (@uris) = _get_body_uris($self,$pms,$bodyref);
   foreach my $this_hostname (@uris) { 
     my $this_domain = $self->{'main'}->{'registryboundaries'}->uri_to_domain($this_hostname);
-    if (!($skip_domains->{$this_hostname})) {
+    if (!($skip_domains->{$this_domain})) {
       dbg("SHPlugin: (check_sh_bodyuri_ns) checking authoritative NS for domain ".$this_domain." from URI ".$this_hostname." found in body");
       my $res   = Net::DNS::Resolver->new;
       $res->udp_timeout(3);

--- a/SH.pm
+++ b/SH.pm
@@ -276,9 +276,12 @@ sub _get_domains_from_body_emails {
     s#<?(?<!mailto:)$self->{email_regex}(?:>|\s{1,10}(?!(?:fa(?:x|csi)|tel|phone|e?-?mail))[a-z]{2,11}:)# #gi;
     while (/$self->{email_regex}/g) {
       my $email = lc($1);
-      my ($this_user, $this_domain )       = split('@', $email);
-      push(@body_domains, $this_domain) unless defined $seen{$this_domain};
-      $seen{$this_domain} = 1;
+      my ($this_user, $this_hostname )     = split('@', $email);
+      my $this_domain = $self->{'main'}->{'registryboundaries'}->uri_to_domain($this_hostname);
+      if ($this_domain) {
+        push(@body_domains, $this_domain) unless defined $seen{$this_domain};
+        $seen{$this_domain} = 1;
+      }
       last BODY if scalar @body_domains >= 40; # sanity
     }
   }

--- a/SH.pm
+++ b/SH.pm
@@ -508,16 +508,17 @@ sub check_sh_helo {
   }
 
   my $helo = $lasthop->{helo};
-  if (!($skip_domains->{$helo})) {
-    dbg ("SHPlugin: (check_sh_helo) checking HELO (helo=$helo)");
-    my $lookup = $helo.".".$list;
+  my $helo_domain = $self->{'main'}->{'registryboundaries'}->uri_to_domain($helo);
+  if ($helo_domain and !($skip_domains->{$helo_domain})) {
+    dbg ("SHPlugin: (check_sh_helo) checking domain $helo_domain of HELO (helo=$helo)");
+    my $lookup = $helo_domain.".".$list;
     my $key = "SH:$lookup";
     my $ent = {
       key => $key,
       zone => $list,
       type => 'SH',
       rulename => $rulename,
-      addr => $helo,
+      addr => $helo_domain,
     };
     $ent = $pms->{async}->bgsend_and_start_lookup($lookup, 'A', undef, $ent, sub {
       my ($ent, $pkt) = @_;
@@ -665,22 +666,25 @@ sub check_sh_reverse {
 
   my $rdns = $lasthop->{rdns};
   if ($rdns) {
-    dbg ("SHPlugin: (check_sh_reverse) checking RDNS of the last untrusted relay (rdns=$rdns)");
-    if ((substr $rdns, -1) eq ".") { chop $rdns; }
-    my $lookup = $rdns.".".$list;
-    my $key = "SH:$lookup";
-    my $ent = {
-      key => $key,
-      zone => $list,
-      type => 'SH',
-      rulename => $rulename,
-      addr => $rdns,
-    };
-    $ent = $pms->{async}->bgsend_and_start_lookup($lookup, 'A', undef, $ent, sub {
-      my ($ent, $pkt) = @_;
-      $self->_finish_lookup($pms, $ent, $pkt, $subtest);
-    }, master_deadline => $pms->{master_deadline});
-    return 0;
+    my $rdns_domain = $self->{'main'}->{'registryboundaries'}->uri_to_domain($rdns);
+    if ($rdns_domain) {
+      dbg ("SHPlugin: (check_sh_reverse) checking domain $rdns_domain of RDNS of the last untrusted relay (rdns=$rdns)");
+      if ((substr $rdns_domain, -1) eq ".") { chop $rdns_domain; }
+      my $lookup = $rdns_domain.".".$list;
+      my $key = "SH:$lookup";
+      my $ent = {
+        key => $key,
+        zone => $list,
+        type => 'SH',
+        rulename => $rulename,
+        addr => $rdns_domain,
+      };
+      $ent = $pms->{async}->bgsend_and_start_lookup($lookup, 'A', undef, $ent, sub {
+        my ($ent, $pkt) = @_;
+        $self->_finish_lookup($pms, $ent, $pkt, $subtest);
+      }, master_deadline => $pms->{master_deadline});
+      return 0;
+    }
   }
 }
 


### PR DESCRIPTION
In several places, the code does lookups against ZRD and DBL for subdomains rather than the domain name itself, causing unnecessary extra queries.

In addition, the code compares subdomains to $skip_domains in several places, instead of comparing the domain name. This results in unnecessary ZRD and DBL queries for "sub.example.com..." even if example.com is in skip_domains.

These changes should fix both problems.