### PR TITLE
Consistently use $self->{'main'}->{'registryboundaries'}->uri_to_domain where appropriate

### DIFF
--- a/SH.pm
+++ b/SH.pm
@@ -648,7 +648,7 @@ sub check_sh_bodyuri_ns {
   (@uris) = _get_body_uris($self,$pms,$bodyref);
   foreach my $this_hostname (@uris) { 
     my $this_domain = $self->{'main'}->{'registryboundaries'}->uri_to_domain($this_hostname);
-    if (!($skip_domains->{$this_hostname})) {
+    if (!($skip_domains->{$this_domain})) {
       dbg("SHPlugin: (check_sh_bodyuri_ns) checking authoritative NS for domain ".$this_domain." from URI ".$this_hostname." found in body");
       my $res   = Net::DNS::Resolver->new;
       $res->udp_timeout(3);

--- a/SH.pm
+++ b/SH.pm
@@ -296,9 +296,12 @@ sub _get_domains_from_body_emails {
     s#<?(?<!mailto:)$self->{email_regex}(?:>|\s{1,10}(?!(?:fa(?:x|csi)|tel|phone|e?-?mail))[a-z]{2,11}:)# #gi;
     while (/$self->{email_regex}/g) {
       my $email = lc($1);
-      my ($this_user, $this_domain )       = split('@', $email);
-      push(@body_domains, $this_domain) unless defined $seen{$this_domain};
-      $seen{$this_domain} = 1;
+      my ($this_user, $this_hostname )     = split('@', $email);
+      my $this_domain = $self->{'main'}->{'registryboundaries'}->uri_to_domain($this_hostname);
+      if ($this_domain) {
+        push(@body_domains, $this_domain) unless defined $seen{$this_domain};
+        $seen{$this_domain} = 1;
+      }
       last BODY if scalar @body_domains >= 40; # sanity
     }
   }


### PR DESCRIPTION
Fix these problems:

The code does lookups against ZRD and DBL for subdomains rather than the domain name itself, causing unnecessary extra queries.

In addition, the code compares subdomains to $skip_domains, instead of comparing the domain name. This results in unnecessary ZRD and DBL queries for "sub.example.com..." even if example.com is in skip_domains.

(This is a replacement for https://github.com/spamhaus/spamassassin-dqs/pull/31, in which I wrongly included an additional change.)