### PR TITLE
PBL check last external only

### DIFF
--- a/sh.cf
+++ b/sh.cf
@@ -32,7 +32,7 @@ ifplugin Mail::SpamAssassin::Plugin::SH
   header	RCVD_IN_XBL		eval:check_rbl('zendqs', 'your_DQS_key.zen.dq.spamhaus.net.', '^127\.0\.0\.[4567]$')
   tflags	RCVD_IN_XBL		net
 
-  header	__RCVD_IN_PBL		eval:check_rbl('zendqs', 'your_DQS_key.zen.dq.spamhaus.net.', '^127\.0\.0\.1[01]$')
+  header	__RCVD_IN_PBL		eval:check_rbl('zendqs-lastexternal', 'your_DQS_key.zen.dq.spamhaus.net.', '^127\.0\.0\.1[01]$')
   tflags	__RCVD_IN_PBL		net
   meta		RCVD_IN_PBL		__RCVD_IN_PBL
 


### PR DESCRIPTION
The PBL list includes end-user IP space. Therefore, it should not be used to check all Received headers. Check last external only. 

From https://www.spamhaus.org/faq/section/Spamhaus%20PBL#503:

> PBL...should not be used to check all the IP addresses appearing in mail headers.