### PR TITLE
Replace rdatastr with rdstring

### DIFF
--- a/3.4.1+/SH.pm
+++ b/3.4.1+/SH.pm
@@ -850,7 +850,7 @@ sub continue_a_record_lookup
 	{
 		if ($rr->type eq 'A')
 		{
-			my $ip_address = $rr->rdatastr;
+			my $ip_address = $rr->rdstring;
 			dbg("SHPlugin: continue_a_record_lookup found A record for URI ".$hname.": ".$ip_address);
 			my $reversed = join ".", reverse split /[.]/, $ip_address;
 			my $lookup = $reversed.".".$ent->{zone};


### PR DESCRIPTION
Within Net::DNS rdatastr has been deprecated, and replaced with rdstring. This is giving a warning when used with the latest Net::DNS