### PR TITLE
Do not disclose dqs api key in default rule description

### DIFF
--- a/3.4.1+/SH.pm
+++ b/3.4.1+/SH.pm
@@ -1122,7 +1122,7 @@ sub _lookup {
             return 0 if ($addr eq '');
             if ($addr =~ $prs->{zone_match}) {
                 dbg("HIT! $digest.$prs->{zone} = $addr ($uri)");
-                $self->_add_desc($pms, $uri, "URIHash hit at $prs->{zone}");
+                $self->_add_desc($pms, $uri, "URIHash hit at ");
                 return 1;
             }
             return 0;
@@ -1147,7 +1147,7 @@ sub _lookup {
                 $pms->{urihash_lookup_cache}{"$digest.$prs->{zone}"} = $rr->address;
                 if ($rr->address =~ $prs->{zone_match}) {
                     dbg("HIT! $digest.$prs->{zone} = $rr->{address} ($uri)");
-                    $self->_add_desc($pms, $uri, "URIHash hit at $prs->{zone}");
+                    $self->_add_desc($pms, $uri, "URIHash hit at ");
                     return 1;
                 }
                 else {

--- a/4.0.0+/SH.pm
+++ b/4.0.0+/SH.pm
@@ -362,7 +362,7 @@ sub _lookup {
             return 0 if ($addr eq '');
             if ($addr =~ $prs->{zone_match}) {
                 dbg("HIT! $digest.$prs->{zone} = $addr ($uri)");
-                $self->_add_desc($pms, $uri, "URIHash hit at $prs->{zone}");
+                $self->_add_desc($pms, $uri, "URIHash hit at ");
                 return 1;
             }
             return 0;
@@ -387,7 +387,7 @@ sub _lookup {
                 $pms->{urihash_lookup_cache}{"$digest.$prs->{zone}"} = $rr->address;
                 if ($rr->address =~ $prs->{zone_match}) {
                     dbg("HIT! $digest.$prs->{zone} = $rr->{address} ($uri)");
-                    $self->_add_desc($pms, $uri, "URIHash hit at $prs->{zone}");
+                    $self->_add_desc($pms, $uri, "URIHash hit at ");
                     return 1;
                 }
                 else {


### PR DESCRIPTION
remove $prs->{zone} from default rule description.
zone contains the DQS API key.