### PR TITLE
Use correct "127.0.1.102-127.0.1.106" range format for SH_DBL_ABUSED_…

### DIFF
--- a/4.0.0+/sh.cf
+++ b/4.0.0+/sh.cf
@@ -159,7 +159,7 @@
   header RCVD_IN_ZEN_BLOCKED    eval:check_rbl('zendqs-lastexternal', 'your_DQS_key.zen.dq.spamhaus.net.', '^127\.255\.255\.255$')
 
 
-  urirhssub	SH_DBL_ABUSED_FULLHOST	your_DQS_key.dbl.dq.spamhaus.net.	A 127.0.1.102-106
+  urirhssub	SH_DBL_ABUSED_FULLHOST	your_DQS_key.dbl.dq.spamhaus.net.	A 127.0.1.102-127.0.1.106
   body		SH_DBL_ABUSED_FULLHOST	eval:check_uridnsbl('SH_DBL_ABUSED_FULLHOST')
   priority	SH_DBL_ABUSED_FULLHOST	-100
   tflags	SH_DBL_ABUSED_FULLHOST notrim


### PR DESCRIPTION
…FULLHOST rather than "127.0.1.102-106"

The previous format of "127.0.1.102-106" does not work in SpamAssassin 4.0+, and causes false negatives like this (note the incorrect "7f000166-0000006a", suggesting "127.0.1.102-106" is expanded to "127.0.1.102-0.0.0.106"):

```
dbg: uridnsbl: geno.link . geno.link.your_DQS_key.dbl.dq.spamhaus.net -> 127.0.1.102, SH_DBL_ABUSED_FULLHOST, subtest:2130706790-106
dbg: uridnsbl: geno.link . geno.link.your_DQS_key.dbl.dq.spamhaus.net -> 127.0.1.102, SH_DBL_ABUSED_FULLHOST, 7f000166 7f000166-0000006a no
```

After this fix, it correctly matches:

```
dbg: uridnsbl: geno.link . geno.link.your_DQS_key.dbl.dq.spamhaus.net -> 127.0.1.102, SH_DBL_ABUSED_FULLHOST, subtest:2130706790-2130706794
dbg: uridnsbl: geno.link . geno.link.your_DQS_key.dbl.dq.spamhaus.net -> 127.0.1.102, SH_DBL_ABUSED_FULLHOST, 7f000166 7f000166-7f00016a match
```