### PR TITLE
Do not use uridnsbl_skip_domain for SH_HBL_EMAILS

### DIFF
--- a/4.0.0+/sh_hbl.cf
+++ b/4.0.0+/sh_hbl.cf
@@ -39,7 +39,8 @@
   priority      SH_HBL_EMAILS_GMAIL	  -100
   describe      SH_HBL_EMAILS_GMAIL	  Email address listed in email blocklist
 
-  header        SH_HBL_EMAILS	eval:check_hashbl_emails('_email.your_DQS_key.hbl.dq.spamhaus.net/A', 'sha1/max=10/shuffle/notag', 'ALLFROM/Reply-To/body', '^127\.0\.3\.2$')
+  hashbl_acl_all = !gmail.com
+  header        SH_HBL_EMAILS	eval:check_hashbl_emails('_email.your_DQS_key.hbl.dq.spamhaus.net/A', 'sha1/max=10/shuffle/notag', 'ALLFROM/Reply-To/body', '^127\.0\.3\.2$', 'all')
   priority      SH_HBL_EMAILS	-100
   describe      SH_HBL_EMAILS	Email address listed in email blocklist
 


### PR DESCRIPTION
If no ACL is used for check_hashbl_emails HashBL.pm will check all domains against uridnsbl_skip_domain which contains many of the big freemail providers. The special ACL "all" definded by hashbl_acl_all allows us to check all domains and also to add exemptions, like gmail.com which is already checked with SH_HBL_EMAILS_GMAIL